### PR TITLE
Download box_url for vagrant over HTTPS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ ip_address = "172.22.22.25"
 Vagrant.configure(2) do |config|
   
   config.vm.box = "Netsoc"
-  config.vm.box_url = "http://files.netsoc.co/f/2e06d99781/?dl=1"
+  config.vm.box_url = "https://files.netsoc.co/f/2e06d99781/?dl=1"
   config.vm.box_check_update = true
 
   # Configuration for our virtualisation provider


### PR DESCRIPTION
The JSON box_url content specifies the boxes then to download the images over HTTP which doesn't matter as there is a sha1sum checksum at that point. At worst at that point the image would be corrupted and waste bandwidth.
